### PR TITLE
fixed a bug by changing erroneous R1r to correct R2r in JWL_f

### DIFF
--- a/exactpack/solvers/riemann/utils.py
+++ b/exactpack/solvers/riemann/utils.py
@@ -11,7 +11,7 @@ def JWL_f(r, g, inst):
   R1r = inst.R1 * r0 / r
   R2r = inst.R2 * r0 / r
   A, B = inst.A, inst.B
-  return A * (1. - G / R1r) * exp(- R1r) + B * (1. - G / R1r) * exp(- R2r)
+  return A * (1. - G / R1r) * exp(- R1r) + B * (1. - G / R2r) * exp(- R2r)
 
 def JWL_dfdr(r, g, inst):
   G  = g - 1.


### PR DESCRIPTION
the `JWL_f` function in `exactpack/solvers/riemann/utils.py` evaluated part of the JWL $`p(v,e)`$ EOS as 
`A * (1. - G / R1r) * exp(- R1r) + B * (1. - G / R1r) * exp(- R2r)`

This should have read

`A * (1. - G / R1r) * exp(- R1r) + B * (1. - G / R2r) * exp(- R2r)`